### PR TITLE
Pick up @ExceptionHandler-s from any parent of a class marked as @ControllerAdvice

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericResponseService.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericResponseService.java
@@ -52,6 +52,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -152,7 +153,7 @@ public class GenericResponseService {
 			if (org.springframework.aop.support.AopUtils.isAopProxy(controllerAdvice))
 				objClz = org.springframework.aop.support.AopUtils.getTargetClass(controllerAdvice);
 			ControllerAdviceInfo controllerAdviceInfo = new ControllerAdviceInfo(controllerAdvice);
-			Arrays.stream(objClz.getDeclaredMethods()).filter(m -> m.isAnnotationPresent(ExceptionHandler.class)).forEach(methods::add);
+			Arrays.stream(ReflectionUtils.getAllDeclaredMethods(objClz)).filter(m -> m.isAnnotationPresent(ExceptionHandler.class)).forEach(methods::add);
 			// for each one build ApiResponse and add it to existing responses
 			for (Method method : methods) {
 				if (!operationService.isHidden(method)) {

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/CommonFooErrorHandler.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/CommonFooErrorHandler.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.app155;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class CommonFooErrorHandler {
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorDTO onException(Exception e) {
+		return new ErrorDTO("Something wrong has happened");
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/ErrorDTO.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/ErrorDTO.java
@@ -1,0 +1,20 @@
+package test.org.springdoc.api.app155;
+
+public class ErrorDTO {
+    private String message;
+
+    public ErrorDTO() {
+    }
+
+    public ErrorDTO(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/HelloController.java
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.app155;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@OpenAPIDefinition(info = @Info(title = "API Examples", version = "1.0"), tags = @Tag(name = "Operations"))
+public class HelloController {
+
+	@GetMapping("/foo")
+	public SimpleDTO hello() {
+		return new SimpleDTO("foo");
+	}
+}
+
+

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/SimpleDTO.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/SimpleDTO.java
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.app155;
+
+public class SimpleDTO {
+
+	private String payload;
+
+	public SimpleDTO() {
+	}
+
+	public SimpleDTO(String payload) {
+		this.payload = payload;
+	}
+
+	public String getPayload() {
+		return payload;
+	}
+
+	public void setPayload(String payload) {
+		this.payload = payload;
+	}
+
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/SpecificFooErrorHandler.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/SpecificFooErrorHandler.java
@@ -1,0 +1,7 @@
+package test.org.springdoc.api.app155;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@ControllerAdvice(assignableTypes = HelloController.class)
+public class SpecificFooErrorHandler extends CommonFooErrorHandler {
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/SpringDocApp155Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app155/SpringDocApp155Test.java
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.app155;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+
+public class SpringDocApp155Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app155.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app155.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "API Examples",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/api/foo": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "hello",
+        "responses": {
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDTO"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorDTO": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "SimpleDTO": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently the library scans  for exception handlers only declared method of `@ControllerAdvice`s. So if an advice extends other classes with exception handlers, handlers will not be picked up.

Sometimes, it might be useful to have one class with common handlers (e.g. a jar library that is imported in all services across a project/company) and extend with more specific handlers.

Something like that


```java
-----------------------------------------
public class Error {
  // ...
}
-----------------------------------------
public class CommonErrorHandler {

  @ResponseStatus(INTERNAL_SERVER_ERROR)
  @ExceptionHandler(Exception.class)
  public Error onException(Exception ex) {
    return new Error();
  }

  // other common handlers
}
-----------------------------------------
@ControllerAdvice
public class ErrorHandler extends CommonErrorHandler {
  
  //additional error handlers
}
-----------------------------------------
```